### PR TITLE
FIX CMakeLists.txt tracy paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,9 @@ add_library(RaptorExternal
     source/external/imgui/TextEditor.cpp
     source/external/imgui/TextEditor.h
 
-    source/external/tracy/Tracy.hpp
-    source/external/tracy/TracyC.h
-    source/external/tracy/TracyVulkan.hpp
+    source/external/tracy/tracy/Tracy.hpp
+    source/external/tracy/tracy/TracyC.h
+    source/external/tracy/tracy/TracyVulkan.hpp
     source/external/tracy/TracyClient.cpp
 
     source/external/enkiTS/LockLessMultiReadPipe.h


### PR DESCRIPTION
Using cmake on Linux, the build command `cmake -B build -DCMAKE_BUILD_TYPE=Debug` fails with the following error:

```
CMake Error at CMakeLists.txt:109 (add_library):
  Cannot find source file:

    source/external/tracy/Tracy.hpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc


CMake Error at CMakeLists.txt:109 (add_library):
  No SOURCES given to target: RaptorExternal
```

The reason being that the tracy path structure has changed. 
This PR updates the 3 wrong entries.