### PR TITLE
Update VMA includes to specify vulkan version 1.1

### DIFF
--- a/source/chapter1/graphics/gpu_device.cpp
+++ b/source/chapter1/graphics/gpu_device.cpp
@@ -39,6 +39,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 #endif // _MSC_VER
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter1/graphics/gpu_device.hpp
+++ b/source/chapter1/graphics/gpu_device.hpp
@@ -10,6 +10,7 @@
 #endif
 #include <vulkan/vulkan.h>
 
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include "graphics/gpu_resources.hpp"

--- a/source/chapter1/graphics/gpu_resources.hpp
+++ b/source/chapter1/graphics/gpu_resources.hpp
@@ -5,6 +5,7 @@
 #include "graphics/gpu_enum.hpp"
 
 #include <vulkan/vulkan.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 namespace raptor {

--- a/source/chapter10/graphics/gpu_device.cpp
+++ b/source/chapter10/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter10/graphics/renderer.cpp
+++ b/source/chapter10/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter11/graphics/gpu_device.cpp
+++ b/source/chapter11/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter11/graphics/renderer.cpp
+++ b/source/chapter11/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter12/graphics/gpu_device.cpp
+++ b/source/chapter12/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter12/graphics/renderer.cpp
+++ b/source/chapter12/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter13/graphics/gpu_device.cpp
+++ b/source/chapter13/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter13/graphics/renderer.cpp
+++ b/source/chapter13/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter14/graphics/gpu_device.cpp
+++ b/source/chapter14/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter14/graphics/renderer.cpp
+++ b/source/chapter14/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter15/graphics/gpu_device.cpp
+++ b/source/chapter15/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter15/graphics/renderer.cpp
+++ b/source/chapter15/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter2/graphics/gpu_device.cpp
+++ b/source/chapter2/graphics/gpu_device.cpp
@@ -40,6 +40,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 #endif // _MSC_VER
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter2/graphics/gpu_device.hpp
+++ b/source/chapter2/graphics/gpu_device.hpp
@@ -10,6 +10,7 @@
 #endif
 #include <vulkan/vulkan.h>
 
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include "graphics/gpu_resources.hpp"

--- a/source/chapter2/graphics/gpu_resources.hpp
+++ b/source/chapter2/graphics/gpu_resources.hpp
@@ -5,6 +5,7 @@
 #include "graphics/gpu_enum.hpp"
 
 #include <vulkan/vulkan.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 namespace raptor {

--- a/source/chapter3/graphics/gpu_device.cpp
+++ b/source/chapter3/graphics/gpu_device.cpp
@@ -40,6 +40,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 #endif // _MSC_VER
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter3/graphics/gpu_device.hpp
+++ b/source/chapter3/graphics/gpu_device.hpp
@@ -10,6 +10,7 @@
 #endif
 #include <vulkan/vulkan.h>
 
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include "graphics/gpu_resources.hpp"

--- a/source/chapter3/graphics/gpu_resources.hpp
+++ b/source/chapter3/graphics/gpu_resources.hpp
@@ -5,6 +5,7 @@
 #include "graphics/gpu_enum.hpp"
 
 #include <vulkan/vulkan.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 namespace raptor {

--- a/source/chapter4/graphics/gpu_device.cpp
+++ b/source/chapter4/graphics/gpu_device.cpp
@@ -42,6 +42,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter4/graphics/gpu_device.hpp
+++ b/source/chapter4/graphics/gpu_device.hpp
@@ -10,6 +10,7 @@
 #endif
 #include <vulkan/vulkan.h>
 
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include "graphics/gpu_resources.hpp"

--- a/source/chapter4/graphics/gpu_resources.hpp
+++ b/source/chapter4/graphics/gpu_resources.hpp
@@ -5,6 +5,7 @@
 #include "graphics/gpu_enum.hpp"
 
 #include <vulkan/vulkan.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 namespace raptor {

--- a/source/chapter5/graphics/gpu_device.cpp
+++ b/source/chapter5/graphics/gpu_device.cpp
@@ -43,6 +43,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter5/graphics/gpu_device.hpp
+++ b/source/chapter5/graphics/gpu_device.hpp
@@ -10,6 +10,7 @@
 #endif
 #include <vulkan/vulkan.h>
 
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include "graphics/gpu_resources.hpp"

--- a/source/chapter5/graphics/gpu_resources.hpp
+++ b/source/chapter5/graphics/gpu_resources.hpp
@@ -5,6 +5,7 @@
 #include "graphics/gpu_enum.hpp"
 
 #include <vulkan/vulkan.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 namespace raptor {

--- a/source/chapter6/graphics/gpu_device.cpp
+++ b/source/chapter6/graphics/gpu_device.cpp
@@ -13,6 +13,7 @@
 #include <windows.h>
 #endif
 
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -50,6 +51,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter6/graphics/renderer.cpp
+++ b/source/chapter6/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter7/graphics/gpu_device.cpp
+++ b/source/chapter7/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter7/graphics/renderer.cpp
+++ b/source/chapter7/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter8/graphics/gpu_device.cpp
+++ b/source/chapter8/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter8/graphics/renderer.cpp
+++ b/source/chapter8/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>

--- a/source/chapter9/graphics/gpu_device.cpp
+++ b/source/chapter9/graphics/gpu_device.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include <vulkan/vk_enum_string_helper.h>
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 template<class T>
@@ -51,6 +52,7 @@ constexpr const T& raptor_max( const T& a, const T& b ) {
 //#define VMA_DEBUG_LOG rprintret
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 // SDL and Vulkan headers

--- a/source/chapter9/graphics/renderer.cpp
+++ b/source/chapter9/graphics/renderer.cpp
@@ -7,6 +7,7 @@
 #include "foundation/file.hpp"
 
 #include "external/imgui/imgui.h"
+#define VMA_VULKAN_VERSION 1001000
 #include "external/vk_mem_alloc.h"
 
 #include <mutex>


### PR DESCRIPTION
First, thank you for writing this book. It creates an excellent bridge from beginner Vulkan programming to expert. 

I had trouble linking VMA on my laptop (which runs only Vulkan 1.2) and realized it was due to VMA using 1.3 functions including vkGetDeviceBufferMemoryRequirements. I was able to link correctly after defining VMA_VULKAN_VERSION to be 1.1 before including "vk_mem_alloc.h". 

Not sure if this pull request is helpful to the project, but thought I would offer it up nonetheless. 