### PR TITLE
Fix garbage written past temp shader

### DIFF
--- a/source/raptor/foundation/file.cpp
+++ b/source/raptor/foundation/file.cpp
@@ -422,7 +422,7 @@ FileReadResult file_read_text( cstring filename, Allocator* allocator ) {
 
         result.data[ bytes_read ] = 0;
 
-        result.size = filesize;
+        result.size = bytes_read;
 
         fclose( file );
     }


### PR DESCRIPTION
Temp shader passed to shader compiler was written to file with garbage at the end (Windows).
Use correct code size.