### PR TITLE
Compute only queue fix

### DIFF
--- a/source/chapter5/graphics/command_buffer.cpp
+++ b/source/chapter5/graphics/command_buffer.cpp
@@ -956,6 +956,9 @@ void CommandBufferManager::init( GpuDevice* gpu_, u32 num_threads ) {
     const u32 total_secondary_buffers = total_pools * k_secondary_command_buffers_count;
     secondary_command_buffers.init( gpu->allocator, total_secondary_buffers );
 
+    const u32 total_compute_buffers = k_max_frames;
+    compute_command_buffers.init(gpu->allocator, k_max_frames, k_max_frames);
+
     for ( u32 i = 0; i < total_buffers; i++ ) {
         VkCommandBufferAllocateInfo cmd = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr };
 
@@ -1001,6 +1004,21 @@ void CommandBufferManager::init( GpuDevice* gpu_, u32 num_threads ) {
         }
     }
 
+    for (u32 i = 0; i < total_compute_buffers; i++) {
+        VkCommandBufferAllocateInfo cmd = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr };
+
+        cmd.commandPool = gpu->compute_frame_pools[i].vulkan_command_pool;
+        cmd.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+        cmd.commandBufferCount = 1;
+
+        CommandBuffer& current_command_buffer = compute_command_buffers[i];
+        vkAllocateCommandBuffers(gpu->vulkan_device, &cmd, &current_command_buffer.vk_command_buffer);
+
+        current_command_buffer.handle = i;
+        current_command_buffer.thread_frame_pool = &gpu->compute_frame_pools[i];
+        current_command_buffer.init(gpu);
+    }
+
     //rprint( "Done\n" );
 }
 
@@ -1014,8 +1032,13 @@ void CommandBufferManager::shutdown() {
         secondary_command_buffers[ i ].shutdown();
     }
 
+    for (u32 i = 0; i < compute_command_buffers.size; ++i) {
+        compute_command_buffers[i].shutdown();
+    }
+
     command_buffers.shutdown();
     secondary_command_buffers.shutdown();
+    compute_command_buffers.shutdown();
     used_buffers.shutdown();
     used_secondary_command_buffers.shutdown();
 }
@@ -1031,30 +1054,41 @@ void CommandBufferManager::reset_pools( u32 frame_index ) {
     }
 }
 
-CommandBuffer* CommandBufferManager::get_command_buffer( u32 frame, u32 thread_index, bool begin ) {
-    const u32 pool_index = pool_from_indices( frame, thread_index );
-    u32 current_used_buffer = used_buffers[ pool_index ];
-    // TODO: how to handle fire-and-forget command buffers ?
-    RASSERT( current_used_buffer < num_command_buffers_per_thread );
-    if ( begin ) {
-        used_buffers[ pool_index ] = current_used_buffer + 1;
+CommandBuffer* CommandBufferManager::get_command_buffer( u32 frame, u32 thread_index, bool begin, bool compute) {
+    CommandBuffer* cb = nullptr;
+
+    if ( compute ) {
+        RASSERT(thread_index == 0);
+        cb = &compute_command_buffers[frame];
+    } else {
+        const u32 pool_index = pool_from_indices(frame, thread_index);
+        u32 current_used_buffer = used_buffers[pool_index];
+        // TODO: how to handle fire-and-forget command buffers ?
+        RASSERT(current_used_buffer < num_command_buffers_per_thread);
+        if (begin) {
+            used_buffers[pool_index] = current_used_buffer + 1;
+        }
+
+        cb = &command_buffers[(pool_index * num_command_buffers_per_thread) + current_used_buffer];
     }
 
-    CommandBuffer* cb = &command_buffers[ ( pool_index * num_command_buffers_per_thread ) + current_used_buffer ];
-    if ( begin ) {
+    if (begin) {
         cb->reset();
         cb->begin();
 
         // Timestamp queries
         GpuThreadFramePools* thread_pools = cb->thread_frame_pool;
         thread_pools->time_queries->reset();
-        vkCmdResetQueryPool( cb->vk_command_buffer, thread_pools->vulkan_timestamp_query_pool, 0, thread_pools->time_queries->time_queries.size );
+        vkCmdResetQueryPool(cb->vk_command_buffer, thread_pools->vulkan_timestamp_query_pool, 0, thread_pools->time_queries->time_queries.size);
 
-        // Pipeline statistics
-        vkCmdResetQueryPool( cb->vk_command_buffer, thread_pools->vulkan_pipeline_stats_query_pool, 0, GpuPipelineStatistics::Count );
+        if (!compute) {
+            // Pipeline statistics
+            vkCmdResetQueryPool(cb->vk_command_buffer, thread_pools->vulkan_pipeline_stats_query_pool, 0, GpuPipelineStatistics::Count);
 
-        vkCmdBeginQuery( cb->vk_command_buffer, thread_pools->vulkan_pipeline_stats_query_pool, 0, 0 );
+            vkCmdBeginQuery(cb->vk_command_buffer, thread_pools->vulkan_pipeline_stats_query_pool, 0, 0);
+        }
     }
+
     return cb;
 }
 

--- a/source/chapter5/graphics/command_buffer.hpp
+++ b/source/chapter5/graphics/command_buffer.hpp
@@ -95,7 +95,7 @@ struct CommandBufferManager {
 
     void                    reset_pools( u32 frame_index );
 
-    CommandBuffer*          get_command_buffer( u32 frame, u32 thread_index, bool begin );
+    CommandBuffer*          get_command_buffer( u32 frame, u32 thread_index, bool begin, bool compute );
     CommandBuffer*          get_secondary_command_buffer( u32 frame, u32 thread_index );
 
     u16                     pool_from_index( u32 index ) { return (u16)index / num_pools_per_frame; }
@@ -103,6 +103,7 @@ struct CommandBufferManager {
 
     Array<CommandBuffer>    command_buffers;
     Array<CommandBuffer>    secondary_command_buffers;
+    Array<CommandBuffer>    compute_command_buffers;
     Array<u8>               used_buffers;       // Track how many buffers were used per thread per frame.
     Array<u8>               used_secondary_command_buffers;
 

--- a/source/chapter5/graphics/gpu_device.hpp
+++ b/source/chapter5/graphics/gpu_device.hpp
@@ -144,7 +144,7 @@ struct GpuDevice : public Service {
     void                            set_buffer_global_offset( BufferHandle buffer, u32 offset );
 
     // Command Buffers ///////////////////////////////////////////////////
-    CommandBuffer*                  get_command_buffer( u32 thread_index, u32 frame_index, bool begin );
+    CommandBuffer*                  get_command_buffer( u32 thread_index, u32 frame_index, bool begin, bool compute = false );
     CommandBuffer*                  get_secondary_command_buffer( u32 thread_index, u32 frame_index );
 
     void                            queue_command_buffer( CommandBuffer* command_buffer );          // Queue command buffer that will not be executed until present is called.
@@ -277,6 +277,7 @@ struct GpuDevice : public Service {
     FramebufferHandle               vulkan_swapchain_framebuffers[ k_max_swapchain_images ]{ k_invalid_index, k_invalid_index, k_invalid_index };
 
     Array<GpuThreadFramePools>      thread_frame_pools;
+    Array<GpuThreadFramePools>      compute_frame_pools;
 
     // Per frame synchronization
     VkSemaphore                     vulkan_render_complete_semaphore[ k_max_frames ];

--- a/source/chapter5/graphics/render_scene.cpp
+++ b/source/chapter5/graphics/render_scene.cpp
@@ -848,7 +848,7 @@ CommandBuffer* RenderScene::update_physics( f32 delta_time, f32 air_density, f32
             }
 
             if ( cb == nullptr ) {
-                cb = gpu.get_command_buffer( 0, gpu.current_frame, true );
+                cb = gpu.get_command_buffer(0, gpu.current_frame, true, true /*compute*/);
 
                 cb->push_marker( "Frame" );
                 cb->push_marker( "async" );
@@ -871,9 +871,10 @@ CommandBuffer* RenderScene::update_physics( f32 delta_time, f32 air_density, f32
         cb->pop_marker();
 
         // If marker are present, then queries are as well.
-        if ( cb->thread_frame_pool->time_queries->allocated_time_query ) {
+        // Graphics queries not available in compute only queues.
+        /*if ( cb->thread_frame_pool->time_queries->allocated_time_query ) {
             vkCmdEndQuery( cb->vk_command_buffer, cb->thread_frame_pool->vulkan_pipeline_stats_query_pool, 0 );
-        }
+        }*/
 
         cb->end();
     }


### PR DESCRIPTION
Create new array of command buffers pools to be used by compute only queue.
Adds new optional argument to CommandBufferManager::get_command_buffer to get compute only command buffers.
Do not use pipeline statistics queries in compute only queue.

Related to: #31 