### PR TITLE
Shutdown temporary string buffer in `process_execute()` on unix systems

### DIFF
--- a/source/raptor/foundation/process.cpp
+++ b/source/raptor/foundation/process.cpp
@@ -179,6 +179,8 @@ bool process_execute( cstring working_directory, cstring process_fullpath, cstri
 
     chdir( current_dir );
 
+    full_cmd_buffer.shutdown();
+
     return execute_success;
 }
 


### PR DESCRIPTION
Linux variant of `process_execute()` function did not shutdown `full_cmd_buffer` causing memory leak